### PR TITLE
Add ARM64 Linux to CI and scripting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,18 @@ on:
 jobs:
   build-linux:
     # We'll run on Ubuntu as it's required for .deb and .snap packages
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.dist.runs-on }}
+    strategy:
+      matrix:
+        dist:
+          - {
+              arch: x64,
+              runs-on: ubuntu-latest
+            }
+          - {
+              arch: arm64,
+              runs-on: ubuntu-24.04-arm
+            }
 
     steps:
       - name: 'Checkout Repository'
@@ -38,9 +49,9 @@ jobs:
       - name: 'Pack Snap'
         id: snap-build
         run: |
-          mkdir -p out/make/snap/x64/
+          mkdir -p out/make/snap/${{ matrix.dist.arch }}/
           # --destructive-mode allows building without a VM/Container
-          sudo snapcraft pack --output out/make/snap/x64/ --destructive-mode
+          sudo snapcraft pack --output out/make/snap/${{ matrix.dist.arch }}/ --destructive-mode
           # Set the snap path as an output for the next steps
           SNAP_PATH=$(find ./out/make/snap -name '*.snap' -type f | head -n 1)
           echo "SNAP_PATH=$SNAP_PATH" >> $GITHUB_ENV

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "electron-vite dev --watch --sourcemap --debug hmr --remote-debugging-port=9222 --outDir=dist --inspect src/main/index.ts",
     "package": "npm run build && electron-forge package",
     "make": "npm run build && electron-forge make",
-    "make:snap": "node scripts/set-snap-version.cjs && mkdir -p out/make/snap/x64/ && snapcraft pack --output out/make/snap/x64/",
+    "make:snap": "ARCH=$(node -e \"console.log(process.arch)\") && node scripts/set-snap-version.cjs && mkdir -p out/make/snap/$ARCH/ && snapcraft pack --output out/make/snap/$ARCH/",
     "rebuild": "electron-rebuild -f -w better-sqlite3"
   },
   "author": "Xibo Signage Ltd",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,9 @@ apps:
 parts:
   app:
     plugin: dump
-    source: out/xibo-player-linux-x64
+    source:
+      - on amd64: out/xibo-player-linux-x64
+      - on arm64: out/xibo-player-linux-arm64
     # STRATEGY: Move custom libraries into the standard system path
     # This prevents 'not found' errors because the loader checks here by default.
     organize:


### PR DESCRIPTION
User request (also my request as well):

https://community.xibo.org.uk/t/will-the-new-linux-player-be-cross-compiled-to-arm64/38127

Tested the player (arm64 dpkg) on my Nvidia Jetson Orin Nano Devkit (running a custom KDE Neon 24.04 image of my own making) and its working well.